### PR TITLE
Fixing deprecated warning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ logs
 results
 
 npm-debug.log
+
+node_modules/
+package-lock.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
-"use strict";
-
 const crypto = require('crypto');
 
 module.exports.calculate = function (cert) {
 	const shasum = crypto.createHash('sha1');
-	shasum.update(new Buffer(cert, 'base64'));
+	shasum.update(new Buffer.from(cert, 'base64'));
+
 	return shasum.digest('hex');
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const assert = require('assert');
 const thumbprint = require('../');
 
@@ -13,6 +11,6 @@ describe('thumbprint.calculate', function () {
   });
 
   it('should return the right thumbprint when passed a base64 buffer', function () {
-    assert.equal(thumbprint.calculate(new Buffer(cert, 'base64')), certThumbprint);
+    assert.equal(thumbprint.calculate(new Buffer.from(cert, 'base64')), certThumbprint);
   });
 });


### PR DESCRIPTION
Hey, guys.

Due to Hacktoberfest 2018, I'm contributing to some packages.

This package of yours was giving the deprecated warning due to Node Buffer() usage. I've fixed that changing it to Buffer.from().

If you guys allow me to rewrite it in TypeScript to make ES6 compliant like this [package](https://github.com/Fazendaaa/tiny-shortener) that I've made, I would love it to do so :)