### PR TITLE
Update mocha and Buffer  usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ logs
 results
 
 npm-debug.log
+node_modules
+package-lock.json
+*~

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Thumbprint
 
 [![Build Status](https://travis-ci.org/auth0/thumbprint.svg?branch=master)](https://travis-ci.org/auth0/thumbprint)
 
-Certificate thumbprint calculator for Node 4, 6 and 8.
+Certificate thumbprint calculator for Node 6+ (test suite requires 12+)
 
 ## Installation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,6 @@ const crypto = require('crypto');
 
 module.exports.calculate = function (cert) {
 	const shasum = crypto.createHash('sha1');
-	shasum.update(new Buffer(cert, 'base64'));
+	shasum.update(Buffer.from(cert, 'base64'));
 	return shasum.digest('hex');
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "mocha": "^5.0.1"
+    "mocha": "^9.2.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,6 @@ describe('thumbprint.calculate', function () {
   });
 
   it('should return the right thumbprint when passed a base64 buffer', function () {
-    assert.equal(thumbprint.calculate(new Buffer(cert, 'base64')), certThumbprint);
+    assert.equal(thumbprint.calculate(Buffer.from(cert, 'base64')), certThumbprint);
   });
 });


### PR DESCRIPTION
### Description

Updates Buffer usage to non-deprecated Buffer.from calls.
Updates mocha to v9 (last one to support Node 12)

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
